### PR TITLE
Integration updates

### DIFF
--- a/contracts/extensions/Purchasable/SlicerPurchasable.sol
+++ b/contracts/extensions/Purchasable/SlicerPurchasable.sol
@@ -27,6 +27,15 @@ abstract contract SlicerPurchasable is ISlicerPurchasable {
     address internal _productsModuleAddress;
     /// Id of the slicer able to call the functions with the `OnlyOnPurchaseFrom` function
     uint256 internal _slicerId;
+    
+    /**
+     * @param productsModuleAddress Known Slicer products module contract that will call onProductPurchase
+     * @param slicerId Slicer id to associate with.
+     */
+    constructor(address productsModuleAddress, uint256 slicerId) {
+        _productsModuleAddress = productsModuleAddress;
+        _slicerId = slicerId;
+    }
 
     /// ============ Modifiers ============
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "slicer-so-hooks",
+  "version": "1.0.0",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",


### PR DESCRIPTION
Added `name` & `version` attributes to package.json. Without these hardhat is not happy with imports such as

```
  "dependencies": {
    "slicer-so-hooks": "git+https://github.com/slice-so/contracts-hooks.git"
  },
```
with
```
Error HH11: An internal invariant was violated: Libraries should have both name and version, or neither one.
```

Also added a constructor to set required storage parameters to improve composability.