### PR TITLE
FC404 experimentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ out/
 # Dotenv file
 .env
 broadcast
+
+# Script output files
+/output/**

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "lib/ERC721A-Upgradeable"]
 	path = lib/ERC721A-Upgradeable
 	url = https://github.com/chiru-labs/ERC721A-Upgradeable
+[submodule "lib/solady"]
+	path = lib/solady
+	url = https://github.com/vectorized/solady

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,9 +3,11 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 fs_permissions = [
-  { access = "read-write", path = "./deployments/31337/data" }, 
-  { access = "read", path = "./out" }
+  { access = "read-write", path = "./deployments/31337/data" },
+  { access = "read", path = "./out" },
+  { access = "read-write", path = "./output" },
 ]
+memory_limit = 50_000_000_000
 
 [rpc_endpoints]
 mainnet = "${RPC_URL_MAINNET}"
@@ -15,8 +17,8 @@ base = "${RPC_URL_BASE}"
 base-goerli = "${RPC_URL_BASE_GOERLI}"
 
 [etherscan]
-mainnet = {key = "${ETHERSCAN_API_KEY_ETHEREUM}"}
-goerli = {key = "${ETHERSCAN_API_KEY_ETHEREUM}", url = "https://api-goerli.etherscan.io/api"}
-op = {key = "${ETHERSCAN_API_KEY_OPTIMISM}"}
-base = {key = "${ETHERSCAN_API_KEY_BASE}", chain = 8453, url = "https://api.basescan.org/api"}
-base-goerli = {key = "${ETHERSCAN_API_KEY_BASE}", chain = 84531, url = "https://api-goerli.basescan.org/api"}
+mainnet = { key = "${ETHERSCAN_API_KEY_ETHEREUM}" }
+goerli = { key = "${ETHERSCAN_API_KEY_ETHEREUM}", url = "https://api-goerli.etherscan.io/api" }
+op = { key = "${ETHERSCAN_API_KEY_OPTIMISM}" }
+base = { key = "${ETHERSCAN_API_KEY_BASE}", chain = 8453, url = "https://api.basescan.org/api" }
+base-goerli = { key = "${ETHERSCAN_API_KEY_BASE}", chain = 84531, url = "https://api-goerli.basescan.org/api" }

--- a/remappings.txt
+++ b/remappings.txt
@@ -5,3 +5,4 @@ forge-std/=lib/forge-std/src/
 @solmate/=lib/solmate/src
 @erc721a/=lib/ERC721A/
 @erc721a-upgradeable/=lib/ERC721A-Upgradeable/
+@solady/=lib/solady/src

--- a/script/Print404.s.sol
+++ b/script/Print404.s.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import {console} from "forge-std/Test.sol";
+import {Script} from "forge-std/Script.sol";
+import {LibPRNG} from "@solady/utils/LibPRNG.sol";
+import {LibString} from "@solady/utils/LibString.sol";
+
+import {IColormapRegistry} from "../src/interfaces/IColormapRegistry.sol";
+
+contract Print404Script is Script {
+    using LibPRNG for LibPRNG.PRNG;
+    using LibString for uint256;
+
+    // -------------------------------------------------------------------------
+    // Deploy addresses
+    // -------------------------------------------------------------------------
+
+    /// @notice Address of the colormap registry.
+    /// @dev Replace this as needed.
+    IColormapRegistry constant COLORMAP_REGISTRY = IColormapRegistry(0x00000000A84FcdF3E9C165e6955945E87dA2cB0D);
+
+    /// @notice Hash of the colormap to print.
+    /// @dev Replace this as needed.
+    bytes8 constant COLORMAP_HASH = bytes8(0xfd29b65966772202);
+
+    /// @notice Seed for the output.
+    /// @dev Replace this as needed.
+    uint256 constant SEED = 0;
+
+    // -------------------------------------------------------------------------
+    // Script `run()`
+    // -------------------------------------------------------------------------
+
+    function run() public {
+        // First, create the seed.
+        LibPRNG.PRNG memory prng = LibPRNG.PRNG(uint256(keccak256(abi.encodePacked(SEED))));
+
+        // We do 512 iterations of the Drunken Bishop algorithm.
+        uint256 index;
+        uint16[] memory counts = new uint16[](4096);
+        counts[0] = 1;
+        uint256 max = 1;
+        for (uint256 i; i < 512;) {
+            for (uint256 seed = prng.state; seed != 0; seed >>= 2) {
+                (uint256 x, uint256 y) = (index & 0x3f, index >> 6);
+
+                assembly {
+                    function get_in_bounds(_index) -> res {
+                        let _x := and(_index, 0x3f)
+                        // We don't need to mask with `0x3f` because we control
+                        // the input.
+                        let _y := shr(6, _index)
+                        res :=
+                            and(
+                                and(shr(_y, 0x3ffffc00000), 1),
+                                or(
+                                    or(
+                                        and(
+                                            and(shr(_x, 0x3ffc00000fff00), 1),
+                                            and(
+                                                shr(
+                                                    add(mul(12, sub(_y, 22)), sub(_x, add(8, mul(34, gt(_x, 21))))),
+                                                    0xf80f80f80f80fffffffffffffbffbffbeffeffe0fc0fc0f81f81f01f01f0
+                                                ),
+                                                1
+                                            )
+                                        ),
+                                        and(and(shr(_y, 0x3c00000000), shr(_x, 0xc0000000300000)), 1)
+                                    ),
+                                    and(
+                                        and(shr(_x, 0xffff000000), 1),
+                                        and(
+                                            shr(
+                                                add(shl(3, sub(_y, 22)), xor(and(_x, 7), mul(7, gt(_x, 31)))),
+                                                0xfcfcfffffffefefefefefefefefefefffffffcfc
+                                            ),
+                                            1
+                                        )
+                                    )
+                                )
+                            )
+                    }
+
+                    // Read down/up
+                    switch and(shr(1, seed), 1)
+                    // Down case
+                    case 0 { index := add(index, shl(6, iszero(or(eq(y, 63), get_in_bounds(add(index, 64)))))) }
+                    // Up case
+                    default { index := sub(index, shl(6, iszero(or(eq(y, 0), get_in_bounds(sub(index, 64)))))) }
+
+                    // Read left/right
+                    switch and(seed, 1)
+                    // Left case
+                    case 0 { index := sub(index, iszero(or(eq(x, 0), get_in_bounds(sub(index, 1))))) }
+                    // Right case
+                    default { index := add(index, iszero(or(eq(x, 63), get_in_bounds(add(index, 1))))) }
+                }
+
+                unchecked {
+                    if (++counts[index] > max) max = counts[index];
+                }
+            }
+
+            // Generate the next pseudorandom number.
+            prng.state = prng.next();
+            unchecked {
+                ++i;
+            }
+        }
+
+        // SVG generation.
+        string memory svg = "";
+        unchecked {
+            for (uint256 i; i < 4096; ++i) {
+                uint16 color = counts[i];
+                assembly {
+                    color := div(mul(color, 255), max)
+                }
+                svg = string.concat(
+                    svg,
+                    '<path d="M',
+                    (i & 0x3f).toString(),
+                    " ",
+                    (i >> 6).toString(),
+                    'h1v1h-1z" fill="#',
+                    COLORMAP_REGISTRY.getValueAsHexString(COLORMAP_HASH, uint8(color)),
+                    '"/>'
+                );
+            }
+        }
+        vm.writeFile(
+            "./output/404.svg",
+            string.concat(
+                '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 64 64" fill="none">',
+                svg,
+                "</svg>"
+            )
+        );
+    }
+}

--- a/src/interfaces/IColormapRegistry.sol
+++ b/src/interfaces/IColormapRegistry.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {IPaletteGenerator} from "./IPaletteGenerator.sol";
+
+/// @title The interface for the colormap registry.
+/// @author fiveoutofnine
+/// @dev A colormap may be defined in 2 ways: (1) via segment data and (2) via a
+/// ``palette generator.''
+///     1. via segment data
+///     2. or via a palette generator ({IPaletteGenerator}).
+/// Segment data contains 1 `uint256` each for red, green, and blue describing
+/// their intensity values along the colormap. Each `uint256` contains 24-bit
+/// words bitpacked together with the following structure (bits are
+/// right-indexed):
+///     | Bits      | Meaning                                              |
+///     | --------- | ---------------------------------------------------- |
+///     | `23 - 16` | Position in the colormap the segment begins from     |
+///     | `15 - 08` | Intensity of R, G, or B the previous segment ends at |
+///     | `07 - 00` | Intensity of R, G, or B the next segment starts at   |
+/// Given some position, the output will be computed via linear interpolations
+/// on the segment data for R, G, and B. A maximum of 10 of these segments fit
+/// within 256 bits, so up to 9 segments can be defined. If you need more
+/// granularity or a nonlinear palette function, you may implement
+/// {IPaletteGenerator} and define a colormap with that.
+interface IColormapRegistry {
+    // -------------------------------------------------------------------------
+    // Errors
+    // -------------------------------------------------------------------------
+
+    /// @notice Emitted when a colormap already exists.
+    /// @param _hash Hash of the colormap's definition.
+    error ColormapAlreadyExists(bytes8 _hash);
+
+    /// @notice Emitted when a colormap does not exist.
+    /// @param _hash Hash of the colormap's definition.
+    error ColormapDoesNotExist(bytes8 _hash);
+
+    /// @notice Emitted when a segment data used to define a colormap does not
+    /// follow the representation outlined in {IColormapRegistry}.
+    /// @param _segmentData Segment data for 1 of R, G, or B. See
+    /// {IColormapRegistry} for its representation.
+    error SegmentDataInvalid(uint256 _segmentData);
+
+    // -------------------------------------------------------------------------
+    // Structs
+    // -------------------------------------------------------------------------
+
+    /// @notice Segment data that defines a colormap when read via piece-wise
+    /// linear interpolation.
+    /// @dev Each param contains 24-bit words, so each one may contain at most
+    /// 9 (24*10 - 1) segments. See {IColormapRegistry} for how the segment data
+    /// should be structured.
+    /// @param r Segment data for red's color value along the colormap.
+    /// @param g Segment data for green's color value along the colormap.
+    /// @param b Segment data for blue's color value along the colormap.
+    struct SegmentData {
+        uint256 r;
+        uint256 g;
+        uint256 b;
+    }
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+
+    /// @notice Emitted when a colormap is registered via a palette generator
+    /// function.
+    /// @param _hash Hash of `_paletteGenerator`.
+    /// @param _paletteGenerator Instance of {IPaletteGenerator} for the
+    /// colormap.
+    event RegisterColormap(bytes8 _hash, IPaletteGenerator _paletteGenerator);
+
+    /// @notice Emitted when a colormap is registered via segment data.
+    /// @param _hash Hash of `_segmentData`.
+    /// @param _segmentData Segment data defining the colormap.
+    event RegisterColormap(bytes8 _hash, SegmentData _segmentData);
+
+    // -------------------------------------------------------------------------
+    // Storage
+    // -------------------------------------------------------------------------
+
+    /// @param _hash Hash of the colormap's definition (palette generator).
+    /// @return IPaletteGenerator Instance of {IPaletteGenerator} for the
+    /// colormap.
+    function paletteGenerators(bytes8 _hash) external view returns (IPaletteGenerator);
+
+    /// @param _hash Hash of the colormap's definition (segment data).
+    /// @return uint256 Segment data for red's color value along the colormap.
+    /// @return uint256 Segment data for green's color value along the colormap.
+    /// @return uint256 Segment data for blue's color value along the colormap.
+    function segments(bytes8 _hash) external view returns (uint256, uint256, uint256);
+
+    // -------------------------------------------------------------------------
+    // Actions
+    // -------------------------------------------------------------------------
+
+    /// @notice Batch register colormaps with palette generators.
+    /// @param _paletteGenerators Array of {IPaletteGenerator} instances for the
+    /// colormap.
+    function batchRegister(IPaletteGenerator[] memory _paletteGenerators) external;
+
+    /// @notice Batch register colormaps with segment data that will be read
+    /// via piece-wise linear interpolation.
+    /// @dev See {IColormapRegistry} for how the segment data should be
+    /// structured.
+    /// @param _segmentDataArray Array of segment data tuples defining the
+    /// colormap.
+    function batchRegister(SegmentData[] memory _segmentDataArray) external;
+
+    /// @notice Register a colormap with a palette generator.
+    /// @param _paletteGenerator Instance of {IPaletteGenerator} for the
+    /// colormap.
+    function register(IPaletteGenerator _paletteGenerator) external;
+
+    /// @notice Register a colormap with segment data that will be read via
+    /// piece-wise linear interpolation.
+    /// @dev See {IColormapRegistry} for how the segment data should be
+    /// structured.
+    /// @param _segmentData Segment data defining the colormap.
+    function register(SegmentData memory _segmentData) external;
+
+    // -------------------------------------------------------------------------
+    // View
+    // -------------------------------------------------------------------------
+
+    /// @notice Get the red, green, and blue color values of a color in a
+    /// colormap at some position.
+    /// @dev Each color value will be returned as a 18 decimal fixed-point
+    /// number in [0, 1]. Note that the function *will not* revert if
+    /// `_position` is an invalid input (i.e. greater than 1e18). This
+    /// responsibility is left to the implementation of {IPaletteGenerator}s.
+    /// @param _hash Hash of the colormap's definition.
+    /// @param _position 18 decimal fixed-point number in [0, 1] representing
+    /// the position in the colormap (i.e. 0 being min, and 1 being max).
+    /// @return uint256 Intensity of red in that color at the position
+    /// `_position`.
+    /// @return uint256 Intensity of green in that color at the position
+    /// `_position`.
+    /// @return uint256 Intensity of blue in that color at the position
+    /// `_position`.
+    function getValue(bytes8 _hash, uint256 _position)
+        external
+        view
+        returns (uint256, uint256, uint256);
+
+    /// @notice Get the hexstring for a color in a colormap at some position.
+    /// @param _hash Hash of the colormap's definition.
+    /// @param _position Position in the colormap (i.e. 0 being min, and 255
+    /// being max).
+    /// @return string Hexstring excluding ``#'' (e.g. `007CFF`) of the color
+    /// at the position `_position`.
+    function getValueAsHexString(bytes8 _hash, uint8 _position)
+        external
+        view
+        returns (string memory);
+
+    /// @notice Get the red, green, and blue color values of a color in a
+    /// colormap at some position.
+    /// @dev Each color value will be returned as a `uint8` number in [0, 255].
+    /// @param _hash Hash of the colormap's definition.
+    /// @param _position Position in the colormap (i.e. 0 being min, and 255
+    /// being max).
+    /// @return uint8 Intensity of red in that color at the position
+    /// `_position`.
+    /// @return uint8 Intensity of green in that color at the position
+    /// `_position`.
+    /// @return uint8 Intensity of blue in that color at the position
+    /// `_position`.
+    function getValueAsUint8(bytes8 _hash, uint8 _position)
+        external
+        view
+        returns (uint8, uint8, uint8);
+}

--- a/src/interfaces/IPaletteGenerator.sol
+++ b/src/interfaces/IPaletteGenerator.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+/// @title The interface for a palette generator.
+/// @author fiveoutofnine
+/// @dev `IPaletteGenerator` contains generator functions for a color's red,
+/// green, and blue color values. Each of these functions is intended to take in
+/// a 18 decimal fixed-point number in [0, 1] representing the position in the
+/// colormap and return the corresponding 18 decimal fixed-point number in
+/// [0, 1] representing the value of each respective color.
+interface IPaletteGenerator {
+    // -------------------------------------------------------------------------
+    // Errors
+    // -------------------------------------------------------------------------
+
+    /// @notice Reverts if the position is not a valid input.
+    /// @dev The position is not a valid input if it is greater than 1e18.
+    /// @param _position Position in the colormap.
+    error InvalidPosition(uint256 _position);
+
+    // -------------------------------------------------------------------------
+    // Generators
+    // -------------------------------------------------------------------------
+
+    /// @notice Computes the intensity of red of the palette at some position.
+    /// @dev The function should revert if `_position` is not a valid input
+    /// (i.e. greater than 1e18). Also, the return value for all inputs must be
+    /// a 18 decimal.
+    /// @param _position Position in the colormap.
+    /// @return uint256 Intensity of red in that color at the position
+    /// `_position`.
+    function r(uint256 _position) external pure returns (uint256);
+
+    /// @notice Computes the intensity of green of the palette at some position.
+    /// @dev The function should revert if `_position` is not a valid input
+    /// (i.e. greater than 1e18). Also, the return value for all inputs must be
+    /// a 18 decimal.
+    /// @param _position Position in the colormap.
+    /// @return uint256 Intensity of green in that color at the position
+    /// `_position`.
+    function g(uint256 _position) external pure returns (uint256);
+
+    /// @notice Computes the intensity of blue of the palette at some position.
+    /// @dev The function should revert if `_position` is not a valid input
+    /// (i.e. greater than 1e18). Also, the return value for all inputs must be
+    /// a 18 decimal.
+    /// @param _position Position in the colormap.
+    /// @return uint256 Intensity of blue in that color at the position
+    /// `_position`.
+    function b(uint256 _position) external pure returns (uint256);
+}


### PR DESCRIPTION
## Description
Generates sample Drunken Bishop art for the NFTs' metadata inside `script/Print404.s.sol` and writes the output to `./output/404.svg`. Run with the following command:

```sh
forge script script/Print404.s.sol -vvv -f base
```

> [!NOTE]
> Requires either an RPC URL for either Ethereum or Base to read from [**fiveoutofnine/colormap-registry**](https://github.com/fiveoutofnine/colormap-registry?tab=readme-ov-file#deployments). Refer to [**REGISTERED_COLORMAPS.md**](https://github.com/fiveoutofnine/colormap-registry/blob/main/REGISTERED_COLORMAPS.md) to switch out the colormap to render with.