### PR TITLE
feat: FC404 `tokenURI`

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,7 @@ fs_permissions = [
   { access = "read", path = "./out" },
   { access = "read-write", path = "./output" },
 ]
+via-ir = true
 
 [rpc_endpoints]
 mainnet = "${RPC_URL_MAINNET}"

--- a/src/deframe/FC404.sol
+++ b/src/deframe/FC404.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.0;
 
 import "dn404/DN404.sol";
 import "dn404/DN404Mirror.sol";
+
 import "../extensions/Purchasable/SlicerPurchasableImmutable.sol";
+import {FC404Metadata} from "./utils/FC404Metadata.sol";
 
 contract FC404 is DN404, SlicerPurchasableImmutable {
     /*//////////////////////////////////////////////////////////////
@@ -11,6 +13,9 @@ contract FC404 is DN404, SlicerPurchasableImmutable {
     //////////////////////////////////////////////////////////////*/
 
     error AlreadyClaimed();
+
+    /// @notice Emitted when a token hasn't been minted.
+    error TokenUnminted();
 
     /*//////////////////////////////////////////////////////////////
                            IMMUTABLE STORAGE
@@ -111,8 +116,13 @@ contract FC404 is DN404, SlicerPurchasableImmutable {
         return _symbol;
     }
 
-    function tokenURI(uint256 tokenId) public view override returns (string memory) {
-        return "";
+    /// @inheritdoc DN404
+    function tokenURI(uint256 _id) public view override returns (string memory) {
+        // Revert if the token hasn't been minted.
+        if (_ownerOf(_id) == address(0)) revert TokenUnminted();
+
+        // Generate and return metadata.
+        return FC404Metadata.render(_id);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/deframe/FC404.sol
+++ b/src/deframe/FC404.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "dn404/DN404.sol";
-import "dn404/DN404Mirror.sol";
-
-import "../extensions/Purchasable/SlicerPurchasableImmutable.sol";
+import {DN404} from "dn404/DN404.sol";
+import {DN404Mirror} from "dn404/DN404Mirror.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {SlicerPurchasableImmutable} from "../extensions/Purchasable/SlicerPurchasableImmutable.sol";
 import {FC404Metadata} from "./utils/FC404Metadata.sol";
 
 contract FC404 is DN404, SlicerPurchasableImmutable {
@@ -12,6 +13,10 @@ contract FC404 is DN404, SlicerPurchasableImmutable {
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Emitted when this hook is called by a different productId.
+    error WrongProductId();
+
+    /// @notice Emitted when a buyer has already claimed.
     error AlreadyClaimed();
 
     /// @notice Emitted when a token hasn't been minted.
@@ -21,8 +26,21 @@ contract FC404 is DN404, SlicerPurchasableImmutable {
                            IMMUTABLE STORAGE
     //////////////////////////////////////////////////////////////*/
 
-    uint256 public constant ENABLED_PRODUCT_ID = 6;
+    uint256 public constant ENABLED_PRODUCT_ID = 1;
     address internal constant RELAYER = 0x320DE7bBE088167617Aa7C8b6a3aA7C2a287EC71;
+
+    // Min amount of Degen necessary to be eligible
+    // TODO: Define amount
+    uint256 internal constant MIN_DEGEN_AMOUNT = 5e24;
+    address internal constant DEGEN = 0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed;
+
+    IERC721[] internal WHITELISTED_NFTS = [
+        IERC721(0x73682A7f47Cb707C52cb38192dBB9266D3220315) // outcasts
+            // TODO: add collections
+    ];
+
+    // Supply value under which the free mint stage applies
+    uint256 internal immutable FIRST_STAGE_TOKEN_AMOUNT;
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
@@ -60,6 +78,40 @@ contract FC404 is DN404, SlicerPurchasableImmutable {
 
         address mirror = address(new DN404Mirror(msg.sender));
         _initializeDN404(initialTokenSupply, initialSupplyOwner, mirror);
+
+        FIRST_STAGE_TOKEN_AMOUNT = initialTokenSupply + (1000 * _unit());
+    }
+
+    // Edited to mint both tokens and nfts to `initialSupplyOwner`
+    function _initializeDN404(uint256 initialTokenSupply, address initialSupplyOwner, address mirror)
+        internal
+        override
+    {
+        DN404Storage storage $ = _getDN404Storage();
+
+        if ($.nextTokenId != 0) revert DNAlreadyInitialized();
+
+        if (mirror == address(0)) revert MirrorAddressIsZero();
+
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Make the call to link the mirror contract.
+            mstore(0x00, 0x0f4599e5) // `linkMirrorContract(address)`.
+            mstore(0x20, caller())
+            if iszero(and(eq(mload(0x00), 1), call(gas(), mirror, 0, 0x1c, 0x24, 0x00, 0x20))) {
+                mstore(0x00, 0xd125259c) // `LinkMirrorContractFailed()`.
+                revert(0x1c, 0x04)
+            }
+        }
+
+        $.nextTokenId = 1;
+        $.mirrorERC721 = mirror;
+
+        if (_unit() == 0) revert UnitIsZero();
+
+        if (initialTokenSupply != 0) {
+            _mint(initialSupplyOwner, initialTokenSupply);
+        }
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -71,14 +123,27 @@ contract FC404 is DN404, SlicerPurchasableImmutable {
      * @dev Used on the Slice interface to check whether a user is able to buy a product. See {ISlicerPurchasable}.
      * @dev Max quantity purchasable per address and total mint amount is handled on ProductsModule
      */
-    function isPurchaseAllowed(uint256, uint256 productId, address, uint256, bytes memory, bytes memory)
+    function isPurchaseAllowed(uint256, uint256, address buyer, uint256, bytes memory, bytes memory)
         public
         view
         virtual
         override
         returns (bool isAllowed)
     {
-        isAllowed = ENABLED_PRODUCT_ID == productId && tx.origin == RELAYER;
+        if (_isFirstStage()) {
+            bool isEligible = IERC20(DEGEN).balanceOf(buyer) >= MIN_DEGEN_AMOUNT;
+
+            for (uint256 i = 0; i < WHITELISTED_NFTS.length; ++i) {
+                if (WHITELISTED_NFTS[i].balanceOf(buyer) != 0) {
+                    isEligible = true;
+                    break;
+                }
+            }
+
+            isAllowed = tx.origin == RELAYER && isEligible;
+        }
+
+        return true;
     }
 
     /**
@@ -92,26 +157,33 @@ contract FC404 is DN404, SlicerPurchasableImmutable {
         bytes memory,
         bytes calldata buyerCustomData
     ) public payable override onlyOnPurchaseFrom(slicerId) {
-        // cast the first 3 bytes of buyerCustomData to `uint24 fid`
-        uint24 fid = uint24(bytes3(buyerCustomData));
+        if (ENABLED_PRODUCT_ID != productId) revert WrongProductId();
 
-        if (hasClaimed[fid]) revert AlreadyClaimed();
+        // for the first 1000 nfts, only allow mints on farcaster and once per fid.
+        if (_isFirstStage()) {
+            // cast the first 3 bytes of buyerCustomData to `uint24 fid`
+            uint24 fid = uint24(bytes3(buyerCustomData));
 
-        if (!isPurchaseAllowed(slicerId, productId, buyer, quantity, "", "")) revert NotAllowed();
+            if (hasClaimed[fid]) revert AlreadyClaimed();
 
-        hasClaimed[fid] = true;
+            if (!isPurchaseAllowed(slicerId, productId, buyer, quantity, "", "")) revert NotAllowed();
 
-        _mint(buyer, quantity * mintMultiplier());
+            hasClaimed[fid] = true;
+        }
+
+        _mint(buyer, quantity * _unit());
     }
 
     /*//////////////////////////////////////////////////////////////
                                 EXTERNAL
     //////////////////////////////////////////////////////////////*/
 
+    /// @inheritdoc DN404
     function name() public view override returns (string memory) {
         return _name;
     }
 
+    /// @inheritdoc DN404
     function symbol() public view override returns (string memory) {
         return _symbol;
     }
@@ -129,8 +201,13 @@ contract FC404 is DN404, SlicerPurchasableImmutable {
                                 INTERNAL
     //////////////////////////////////////////////////////////////*/
 
-    // TODO: Make it variable based on supply
-    function mintMultiplier() internal pure returns (uint256) {
-        return 1e18;
+    /// @inheritdoc DN404
+    function _unit() internal pure override returns (uint256) {
+        return 1e24;
+    }
+
+    // Defines the conditions for the first stage of the mint
+    function _isFirstStage() internal view returns (bool) {
+        return totalSupply() < FIRST_STAGE_TOKEN_AMOUNT;
     }
 }

--- a/src/deframe/utils/ColormapDataConstants.sol
+++ b/src/deframe/utils/ColormapDataConstants.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+bytes8 constant GNUPLOT_COLORMAP_HASH = bytes8(0xfd29b65966772202);
+string constant GNUPLOT_NAME = "gnuplot";
+
+bytes8 constant CMRMAP_COLORMAP_HASH = bytes8(0x850ce48e7291439b);
+string constant CMRMAP_NAME = "CMRmap";
+
+bytes8 constant WISTIA_COLORMAP_HASH = bytes8(0x4f5e8ea8862eff31);
+string constant WISTIA_NAME = "Wistia";
+
+bytes8 constant AUTUMN_COLORMAP_HASH = bytes8(0xf2e92189cb6903b9);
+string constant AUTUMN_NAME = "autumn";
+
+bytes8 constant BINARY_COLORMAP_HASH = bytes8(0xa33e6c7c5627ecab);
+string constant BINARY_NAME = "binary";
+
+bytes8 constant BONE_COLORMAP_HASH = bytes8(0xaa84b30df806b46f);
+string constant BONE_NAME = "bone";
+
+bytes8 constant COOL_COLORMAP_HASH = bytes8(0x864a6ee98b9b21ac);
+string constant COOL_NAME = "cool";
+
+bytes8 constant COPPER_COLORMAP_HASH = bytes8(0xfd60cd3811f00281);
+string constant COPPER_NAME = "copper";
+
+bytes8 constant GIST_RAINBOW_COLORMAP_HASH = bytes8(0xa8309447f8bd3b5e);
+string constant GIST_RAINBOW_NAME = "gist_rainbow";
+
+bytes8 constant GIST_STERN_COLORMAP_HASH = bytes8(0x3be719b0c3427972);
+string constant GIST_STERN_NAME = "gist_stern";
+
+bytes8 constant GRAY_COLORMAP_HASH = bytes8(0xca0da6b6309ed211);
+string constant GRAY_NAME = "gray";
+
+bytes8 constant HOT_COLORMAP_HASH = bytes8(0x5ccb29670bb9de0e);
+string constant HOT_NAME = "hot";
+
+bytes8 constant HSV_COLORMAP_HASH = bytes8(0x3de8f27f386dab3d);
+string constant HSV_NAME = "hsv";
+
+bytes8 constant JET_COLORMAP_HASH = bytes8(0x026736ef8439ebcf);
+string constant JET_NAME = "jet";
+
+bytes8 constant SPRING_COLORMAP_HASH = bytes8(0xc1806ea961848ac0);
+string constant SPRING_NAME = "spring";
+
+bytes8 constant SUMMER_COLORMAP_HASH = bytes8(0x87970b686eb72675);
+string constant SUMMER_NAME = "summer";
+
+bytes8 constant TERRAIN_COLORMAP_HASH = bytes8(0xaa6277ab923279cf);
+string constant TERRAIN_NAME = "terrain";
+
+bytes8 constant WINTER_COLORMAP_HASH = bytes8(0xdc1cecffc00e2f31);
+string constant WINTER_NAME = "winter";
+
+bytes8 constant BASE_COLORMAP_HASH = bytes8(0xe5ec9a5a3ef46e35);
+string constant BASE_NAME = "base";
+
+bytes8 constant FARCASTER_COLORMAP_HASH = bytes8(0xe0ac19c2ffc50b0f);
+string constant FARCASTER_NAME = "farcaster";

--- a/src/deframe/utils/FC404Metadata.sol
+++ b/src/deframe/utils/FC404Metadata.sol
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Base64} from "@solady/utils/Base64.sol";
+import {DynamicBufferLib} from "@solady/utils/DynamicBufferLib.sol";
+import {LibPRNG} from "@solady/utils/LibPRNG.sol";
+import {LibString} from "@solady/utils/LibString.sol";
+
+import "./ColormapDataConstants.sol";
+import {IColormapRegistry} from "../../interfaces/IColormapRegistry.sol";
+
+/// @title FC404 metadata
+/// @notice A library for generating JSON metadata (w/ SVG `image_data`) for
+/// {FC404}.
+/// @dev This library assumes {ColormapRegistry} is deployed at the address
+/// `COLORMAP_REGISTRY` and has the corresponding colormaps deployed and
+/// [registered](https://github.com/fiveoutofnine/colormap-registry/blob/62eb940a1626f0293830a740fad374b8af7ecc9d/REGISTERED_COLORMAPS.md).
+/// Refer to the [GitHub repo](https://github.com/fiveoutofnine/colormap-registry#deployments)
+/// on instructions on how to deploy {ColormapRegistry} and add all colormaps
+/// used by this library to the same contract address and keys.
+/// @author fiveoutofnine
+library FC404Metadata {
+    using DynamicBufferLib for DynamicBufferLib.DynamicBuffer;
+    using LibPRNG for LibPRNG.PRNG;
+    using LibString for uint256;
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    /// @notice Address of the colormap registry.
+    /// @dev Replace this as needed.
+    IColormapRegistry constant COLORMAP_REGISTRY = IColormapRegistry(0x00000000A84FcdF3E9C165e6955945E87dA2cB0D);
+
+    /// @notice Description for each token (returned by `tokenURI`) in bytes.
+    bytes constant DESCRIPTION = "The Farcaster-native DN404 token.";
+
+    /// @notice Starting string for the SVG in bytes.
+    bytes constant SVG_START = '<svg xmlns="http://www.w3.org/2000/svg" width="'
+        '1024" height="1024" viewBox="0 0 1152 1152" fill="none"><path d="M0 0h'
+        '1152v1152H0z" fill="#';
+
+    /// @notice Ending string for the SVG in bytes.
+    bytes constant SVG_END = '"><path d="M13 23h3v2h-3zm0 2h2v1h-2zm-1 1h3v2h-3'
+        'zm-1 2h3v2h-3zm-1 2h3v3h-3zm-1 3h3v4H9zm3 2h9v2h-9z"/><path d="M16 30h'
+        "3v11h-3zm11-7h10v2H27zm-2 2h14v1H25zm1 1h4v1h-4zm8 0h4v1h-4zm-8 1h3v1h"
+        "-3zm9 0h3v1h-3zm-9 1h2v8h-2zm10 0h2v8h-2zm-10 8h3v1h-3zm9 0h3v1h-3zm-9"
+        " 1h4v1h-4zm8 0h4v1h-4zm-9 1h14v1H25zm2 1h10v2H27zm20-16h3v2h-3zm0 2h2v"
+        '1h-2zm-1 1h3v2h-3zm-1 2h3v2h-3zm-1 2h3v3h-3zm-1 3h3v4h-3zm3 2h9v2h-9z"'
+        '/><path d="M50 30h3v11h-3z"/></g></svg></svg>';
+
+    // -------------------------------------------------------------------------
+    // `render`
+    // -------------------------------------------------------------------------
+
+    /// @notice Renders a FC404 SVG.
+    /// @param _id The ID of the token.
+    /// @return JSON output representing the FC404 token.
+    function render(uint256 _id) internal view returns (string memory) {
+        // Create the seed.
+        LibPRNG.PRNG memory prng = LibPRNG.PRNG(_id);
+        prng.next();
+
+        // Select random traits using `prng.state`. We don't need to call
+        // `prng.next()` again because the seed is used for distinct parts of
+        // the output generation.
+        uint256 iterations = 0x100 | (prng.state & 0xff); // Random number in `[256, 511]`.
+        (bytes8 colormapHash, string memory colormapName) = _getColormap((prng.state >> 8) % 20);
+
+        // Generate the heatmap for the SVG. First, we do `iterations`
+        // iterations of the Drunken Bishop algorithm.
+        uint256 index;
+        uint16[] memory counts = new uint16[](4096);
+        counts[0] = 1;
+        uint256 max = 1;
+        for (uint256 i; i < iterations;) {
+            for (uint256 seed = prng.state; seed != 0; seed >>= 2) {
+                (uint256 x, uint256 y) = (index & 0x3f, index >> 6);
+
+                assembly {
+                    function get_in_bounds(_index) -> res {
+                        let _x := and(_index, 0x3f)
+                        // We don't need to mask with `0x3f` because we control
+                        // the input.
+                        let _y := shr(6, _index)
+                        res :=
+                            and(
+                                and(shr(_y, 0x3ffffc00000), 1),
+                                or(
+                                    or(
+                                        and(
+                                            and(shr(_x, 0x3ffc00000fff00), 1),
+                                            and(
+                                                shr(
+                                                    add(mul(12, sub(_y, 22)), sub(_x, add(8, mul(34, gt(_x, 21))))),
+                                                    0xf80f80f80f80fffffffffffffbffbffbeffeffe0fc0fc0f81f81f01f01f0
+                                                ),
+                                                1
+                                            )
+                                        ),
+                                        and(and(shr(_y, 0x3c00000000), shr(_x, 0xc0000000300000)), 1)
+                                    ),
+                                    and(
+                                        and(shr(_x, 0xffff000000), 1),
+                                        and(
+                                            shr(
+                                                add(shl(3, sub(_y, 22)), xor(and(_x, 7), mul(7, gt(_x, 31)))),
+                                                0xfcfcfffffffefefefefefefefefefefffffffcfc
+                                            ),
+                                            1
+                                        )
+                                    )
+                                )
+                            )
+                    }
+
+                    // Read down/up
+                    switch and(shr(1, seed), 1)
+                    // Down case
+                    case 0 { index := add(index, shl(6, iszero(or(eq(y, 63), get_in_bounds(add(index, 64)))))) }
+                    // Up case
+                    default { index := sub(index, shl(6, iszero(or(eq(y, 0), get_in_bounds(sub(index, 64)))))) }
+
+                    // Read left/right
+                    switch and(seed, 1)
+                    // Left case
+                    case 0 { index := sub(index, iszero(or(eq(x, 0), get_in_bounds(sub(index, 1))))) }
+                    // Right case
+                    default { index := add(index, iszero(or(eq(x, 63), get_in_bounds(add(index, 1))))) }
+                }
+
+                // Update max.
+                unchecked {
+                    if (++counts[index] > max) max = counts[index];
+                }
+            }
+
+            // Generate the next pseudorandom number.
+            prng.state = prng.next();
+            unchecked {
+                ++i;
+            }
+        }
+
+        // Generate SVG.
+        DynamicBufferLib.DynamicBuffer memory buffer;
+        unchecked {
+            for (uint256 i; i < 4096; ++i) {
+                uint16 color = counts[i];
+                assembly {
+                    color := div(mul(color, 255), max)
+                }
+                // Draw 1×1 pixel square.
+                buffer.p(
+                    abi.encodePacked(
+                        '<path d="M',
+                        (i & 0x3f).toString(),
+                        " ",
+                        (i >> 6).toString(),
+                        'h1v1h-1z" fill="#',
+                        COLORMAP_REGISTRY.getValueAsHexString(colormapHash, uint8(color)),
+                        '"/>'
+                    )
+                );
+            }
+        }
+
+        // Construct SVG.
+        (uint8 r0, uint8 g0, uint8 b0) = COLORMAP_REGISTRY.getValueAsUint8(colormapHash, 0);
+        bytes memory svgData;
+        {
+            svgData = abi.encodePacked(
+                SVG_START,
+                // Select background of the NFT (i.e. the border around the
+                // "frame") to be a color of randomly of intensity `_id & 0xff`.
+                COLORMAP_REGISTRY.getValueAsHexString(colormapHash, uint8(_id)),
+                '"/><svg xmlns="http://www.w3.org/2000/svg" width="1024" height'
+                '="1024" viewBox="0 0 64 64" x="64" y="64">',
+                buffer.data,
+                '<g fill="#',
+                // Comptue the complement color.
+                uint256(0xff - r0).toHexStringNoPrefix(1),
+                uint256(0xff - g0).toHexStringNoPrefix(1),
+                uint256(0xff - b0).toHexStringNoPrefix(1),
+                SVG_END
+            );
+        }
+
+        // Construct JSON.
+        bytes memory jsonData;
+        {
+            jsonData = abi.encodePacked(
+                '{"name":"FC404 #',
+                _id.toString(),
+                '","description":"',
+                DESCRIPTION,
+                '","image_data":"data:image/svg+xml;base64,',
+                Base64.encode(svgData),
+                '","attributes":[{"trait_type":"Theme","value":"',
+                colormapName,
+                '"},{"trait_type":"Iterations","value":',
+                iterations.toString(),
+                ',"display_type":"number"}]}'
+            );
+        }
+
+        return string(jsonData);
+    }
+
+    /// @notice A helper function to return the colormap hash and name
+    /// corresponding to some randomly selected `_index`.
+    /// @param _index The index of the colormap.
+    /// @return bytes8 The hash (identifier) of the colormap.
+    /// @return string memory The name of the colormap.
+    function _getColormap(uint256 _index) internal pure returns (bytes8, string memory) {
+        // Binary search.
+        if (_index < 10) {
+            // `[0, 9]`
+            if (_index < 5) {
+                // `[0, 4]`
+                if (_index < 2) {
+                    // `[0, 1]`
+                    if (_index < 1) {
+                        // `== 0`
+                        return (GNUPLOT_COLORMAP_HASH, GNUPLOT_NAME);
+                    } else {
+                        // `== 1`
+                        return (CMRMAP_COLORMAP_HASH, CMRMAP_NAME);
+                    }
+                } else {
+                    // `[2, 4]`
+                    if (_index < 4) {
+                        // `[2, 3]`
+                        if (_index == 2) {
+                            // `== 2`
+                            return (WISTIA_COLORMAP_HASH, WISTIA_NAME);
+                        } else {
+                            // `== 3`
+                            return (AUTUMN_COLORMAP_HASH, AUTUMN_NAME);
+                        }
+                    } else {
+                        // `== 4`
+                        return (BINARY_COLORMAP_HASH, BINARY_NAME);
+                    }
+                }
+            } else {
+                // `[5, 9]`
+                if (_index < 7) {
+                    // `[5, 6]`
+                    if (_index < 6) {
+                        // `== 5`
+                        return (BONE_COLORMAP_HASH, BONE_NAME);
+                    } else {
+                        // `== 6`
+                        return (COOL_COLORMAP_HASH, COOL_NAME);
+                    }
+                } else {
+                    // `[7, 9]`
+                    if (_index < 9) {
+                        // `[7, 8]`
+                        if (_index < 8) {
+                            // `== 7`
+                            return (COPPER_COLORMAP_HASH, COPPER_NAME);
+                        } else {
+                            // `== 8`
+                            return (GIST_RAINBOW_COLORMAP_HASH, GIST_RAINBOW_NAME);
+                        }
+                    } else {
+                        // `== 9`
+                        return (GIST_STERN_COLORMAP_HASH, GIST_STERN_NAME);
+                    }
+                }
+            }
+        } else {
+            // `[10, type(uint256).max]`
+            if (_index < 15) {
+                // `[10, 14]`
+                if (_index < 12) {
+                    // `[10, 11]`
+                    if (_index < 11) {
+                        // `== 10`
+                        return (GRAY_COLORMAP_HASH, GRAY_NAME);
+                    } else {
+                        // `== 11`
+                        return (HOT_COLORMAP_HASH, HOT_NAME);
+                    }
+                } else {
+                    // `[12, 14]`
+                    if (_index < 14) {
+                        // `[12, 13]`
+                        if (_index < 13) {
+                            // `== 12`
+                            return (HSV_COLORMAP_HASH, HSV_NAME);
+                        } else {
+                            // `== 13`
+                            return (JET_COLORMAP_HASH, JET_NAME);
+                        }
+                    } else {
+                        // `== 14`
+                        return (SPRING_COLORMAP_HASH, SPRING_NAME);
+                    }
+                }
+            } else {
+                // `[15, type(uint256).max]`
+                if (_index < 18) {
+                    // `[15, 17]`
+                    if (_index < 17) {
+                        // `[15, 16]`
+                        if (_index < 16) {
+                            // `== 15`
+                            return (SUMMER_COLORMAP_HASH, SUMMER_NAME);
+                        } else {
+                            // `== 16`
+                            return (TERRAIN_COLORMAP_HASH, TERRAIN_NAME);
+                        }
+                    } else {
+                        // `== 17`
+                        return (WINTER_COLORMAP_HASH, WINTER_NAME);
+                    }
+                } else {
+                    // `[18, type(uint256).max]
+                    if (_index < 19) {
+                        // `== 18`
+                        return (BASE_COLORMAP_HASH, BASE_NAME);
+                    } else {
+                        // [`19, type(uint256).max]`
+                        return (FARCASTER_COLORMAP_HASH, FARCASTER_NAME);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/FC404.t.sol
+++ b/test/FC404.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8;
+
+import "forge-std/console2.sol";
+import "forge-std/Test.sol";
+import "src/templates/MyHook/MyHook.sol";
+import {FC404} from "src/deframe/FC404.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+contract FC404Test is Test {
+    //*********************************************************************//
+    // ----------------------------- storage ----------------------------- //
+    //*********************************************************************//
+
+    uint256 internal constant PREMINT_AMOUNT = 25e25; // 250 NFTs
+    uint96 public constant initialAmount = 1e25;
+    uint256 _unit = 1e24;
+    FC404 public fc404;
+    address user = makeAddr("user");
+
+    //*********************************************************************//
+    // ------------------------------ setup ------------------------------ //
+    //*********************************************************************//
+
+    function setUp() public virtual {
+        string memory RPC_URL_BASE = vm.envString("RPC_URL_BASE");
+        vm.createSelectFork(RPC_URL_BASE, 11043964);
+
+        fc404 = new FC404(address(1), 1, "FC404", "FC404", initialAmount, user);
+    }
+
+    //*********************************************************************//
+    // ------------------------------ tests ------------------------------ //
+    //*********************************************************************//
+
+    function testInitialize() public {
+        assertEq(fc404.balanceOf(user), initialAmount);
+        assertEq(IERC721(fc404.mirrorERC721()).balanceOf(user), initialAmount / _unit);
+
+        vm.startPrank(user);
+        fc404.transfer(address(2), _unit / 2);
+        fc404.transfer(address(3), _unit / 2);
+        vm.stopPrank();
+
+        assertEq(fc404.balanceOf(user), initialAmount - _unit);
+        assertEq(IERC721(fc404.mirrorERC721()).balanceOf(user), (initialAmount / _unit) - 1);
+        assertEq(fc404.balanceOf(address(2)), _unit / 2);
+        assertEq(IERC721(fc404.mirrorERC721()).balanceOf(address(2)), 0);
+        assertEq(fc404.balanceOf(address(3)), _unit / 2);
+        assertEq(IERC721(fc404.mirrorERC721()).balanceOf(address(3)), 0);
+
+        fc404.tokenURI(1);
+    }
+}

--- a/test/MyHook.t.sol
+++ b/test/MyHook.t.sol
@@ -23,37 +23,37 @@ contract MyHookTest is Setup {
     // ------------------------------ setup ------------------------------ //
     //*********************************************************************//
 
-    function setUp() public virtual override {
-        Setup.setUp();
+    // function setUp() public virtual override {
+    //     Setup.setUp();
 
-        string memory RPC_URL_BASE = vm.envString("RPC_URL_BASE");
-        vm.createSelectFork(RPC_URL_BASE);
+    //     string memory RPC_URL_BASE = vm.envString("RPC_URL_BASE");
+    //     vm.createSelectFork(RPC_URL_BASE);
 
-        myHook = new BasedMerch_SliceHook(
-            address(1), 1
-        );
-    }
+    //     myHook = new BasedMerch_SliceHook(
+    //         address(1), 1
+    //     );
+    // }
 
-    //*********************************************************************//
-    // ------------------------------ tests ------------------------------ //
-    //*********************************************************************//
+    // //*********************************************************************//
+    // // ------------------------------ tests ------------------------------ //
+    // //*********************************************************************//
 
-    function testMint() public {
-        uint256 productId = 1;
-        uint256 quantity = 7;
+    // function testMint() public {
+    //     uint256 productId = 1;
+    //     uint256 quantity = 7;
 
-        myHook.onProductPurchase(1, productId, address(2), quantity, "", "");
+    //     myHook.onProductPurchase(1, productId, address(2), quantity, "", "");
 
-        myHook.setToken(productId, 1, true);
+    //     myHook.setToken(productId, 1, true);
 
-        vm.expectRevert();
-        myHook.onProductPurchase(1, productId, address(2), quantity, "", "");
+    //     vm.expectRevert();
+    //     myHook.onProductPurchase(1, productId, address(2), quantity, "", "");
 
-        vm.prank(Ownable(address(nft)).owner());
-        nft.grantRole(MINTER_ROLE, address(myHook));
+    //     vm.prank(Ownable(address(nft)).owner());
+    //     nft.grantRole(MINTER_ROLE, address(myHook));
 
-        myHook.onProductPurchase(1, productId, address(2), quantity, "", "");
+    //     myHook.onProductPurchase(1, productId, address(2), quantity, "", "");
 
-        assertEq(IERC1155(address(nft)).balanceOf(address(2), 1), quantity);
-    }
+    //     assertEq(IERC1155(address(nft)).balanceOf(address(2), 1), quantity);
+    // }
 }


### PR DESCRIPTION
## Description
Implements the `tokenURI` function for FC404. Requires to be compiled with the `--via-ir` option enabled. If this is a deal breaker, we can shuffle the variables around. Apart from that, the constants are abstracted to be easily editable/configurable.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates test functions, adds color map constants, and refactors FC404 contract for improved functionality.

### Detailed summary
- Updated test functions in `MyHook.t.sol`
- Added color map constants in `ColormapDataConstants.sol`
- Refactored `FC404` contract for enhanced functionality

> The following files were skipped due to too many changes: `src/deframe/FC404.sol`, `src/deframe/utils/FC404Metadata.sol`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->