### PR TITLE
FC404 animation poc scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ broadcast
 # Script output files
 /output/svg/**
 /output/txt/**
+/output/prngs/**
 
 # Mac
 .DS_Store

--- a/script/PrintFC404.s.sol
+++ b/script/PrintFC404.s.sol
@@ -10,7 +10,7 @@ import {LibString} from "@solady/utils/LibString.sol";
 
 import {IColormapRegistry} from "../src/interfaces/IColormapRegistry.sol";
 
-contract Print404Script is Script {
+contract PrintFC404Script is Script {
     using DynamicBufferLib for DynamicBufferLib.DynamicBuffer;
     using LibPRNG for LibPRNG.PRNG;
     using LibString for uint256;

--- a/script/PrintFC404PRNGSeed.s.sol
+++ b/script/PrintFC404PRNGSeed.s.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {Script} from "forge-std/Script.sol";
+import {DynamicBufferLib} from "@solady/utils/DynamicBufferLib.sol";
+import {LibPRNG} from "@solady/utils/LibPRNG.sol";
+import {LibString} from "@solady/utils/LibString.sol";
+
+import {FC404Metadata} from "src/deframe/utils/FC404Metadata.sol";
+
+contract PrintFC404PRNGSeedScript is Script {
+    using DynamicBufferLib for DynamicBufferLib.DynamicBuffer;
+    using LibPRNG for LibPRNG.PRNG;
+    using LibString for uint256;
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    /// @notice ID of the token to write PRNG seed values for.
+    /// @dev Replace this as needed.
+    uint256 constant TOKEN_ID = 0;
+
+    // -------------------------------------------------------------------------
+    // Script `run()`
+    // -------------------------------------------------------------------------
+
+    function run() public {
+        DynamicBufferLib.DynamicBuffer memory buffer;
+        LibPRNG.PRNG memory prng = LibPRNG.PRNG(TOKEN_ID);
+        prng.next();
+
+        uint256 iterations = 0x100 | (prng.state & 0xff);
+        for (uint256 i; i < iterations - 1;) {
+            buffer.p(abi.encodePacked(prng.state.toHexString(), "-"));
+            prng.next();
+            unchecked {
+                ++i;
+            }
+        }
+        buffer.p(abi.encodePacked(prng.state.toHexString()));
+
+        vm.writeFile(string.concat("./output/prngs/", TOKEN_ID.toString(), ".txt"), string(buffer.data));
+    }
+}

--- a/src/deframe/utils/FC404Metadata.sol
+++ b/src/deframe/utils/FC404Metadata.sol
@@ -204,7 +204,7 @@ library FC404Metadata {
             );
         }
 
-        return string(jsonData);
+        return string.concat("data:json/application;base64,", Base64.encode(jsonData));
     }
 
     /// @notice A helper function to return the colormap hash and name


### PR DESCRIPTION
## Description
Fixes `FC404Metadata` output (JSON output is now base 64 encoded and prefixed with `data:json/application;base64,`). 

Also adds a script to generate all PRNG seeds for a given FC404 token ID with concatenated with `-` as a delimiter to `./output/prngs/{TOKEN_ID}.txt`. To run the script, run the following command:

```sh
forge script script/PrintFC404PRNGSeed.s.sol
```

<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to update script names and add functionality to generate PRNG seed values for a specific token ID.

### Detailed summary
- Renamed `Print404Script` to `PrintFC404Script`
- Added `PrintFC404PRNGSeedScript` to generate PRNG seed values for a specific token ID
- Included constants and script logic for PRNG seed generation
- Updated file paths and imports for consistency

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->